### PR TITLE
refactor: styled-components 를 emotion 으로 대체

### DIFF
--- a/emotion.d.ts
+++ b/emotion.d.ts
@@ -1,4 +1,5 @@
 import '@emotion/react';
+import { PropsWithChildren } from 'react';
 
 declare module '@emotion/react' {
   export interface Theme {

--- a/emotion.d.ts
+++ b/emotion.d.ts
@@ -1,0 +1,34 @@
+import '@emotion/react';
+
+declare module '@emotion/react' {
+  export interface Theme {
+    font: {
+      size16: string;
+      size18: string;
+      size22: string;
+      size80: string;
+    };
+    color: {
+      primary: string;
+      white: string;
+      black: string;
+      darkgrey: string;
+    };
+    gutter: {
+      size8: string;
+      size12: string;
+      size16: string;
+      size20: string;
+      size24: string;
+      size28: string;
+      size32: string;
+      size36: string;
+      size40: string;
+      size56: string;
+      size64: string;
+      size84: string;
+      size88: string;
+      size136: string;
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "react-router-dom": "^6.3.0",
         "recoil": "^0.7.1",
         "style-loader": "^3.3.1",
-        "styled-components": "^5.3.5",
         "tailwindcss": "^3.0.24",
         "ts-loader": "^9.2.8",
         "typescript": "^4.6.3",
@@ -1884,12 +1883,6 @@
         }
       }
     },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-      "dev": true
-    },
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
@@ -3064,28 +3057,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
-      },
-      "peerDependencies": {
-        "styled-components": ">= 2"
-      }
-    },
-    "node_modules/babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3320,12 +3291,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
-      "dev": true
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001332",
@@ -3655,15 +3620,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/css-loader": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
@@ -3719,17 +3675,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
-      "dev": true,
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -6691,13 +6636,6 @@
         "react": "^18.1.0"
       }
     },
-    "node_modules/react-is": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
-      "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/react-query": {
       "version": "3.38.0",
       "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.38.0.tgz",
@@ -7251,12 +7189,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7458,37 +7390,6 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
       }
     },
     "node_modules/stylis": {
@@ -9772,12 +9673,6 @@
         "@emotion/utils": "^1.1.0"
       }
     },
-    "@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-      "dev": true
-    },
     "@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
@@ -10704,25 +10599,6 @@
         "@babel/helper-define-polyfill-provider": "^0.3.1"
       }
     },
-    "babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
-      }
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -10906,12 +10782,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true
-    },
-    "camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
       "dev": true
     },
     "caniuse-lite": {
@@ -11165,12 +11035,6 @@
         "which": "^2.0.1"
       }
     },
-    "css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
-      "dev": true
-    },
     "css-loader": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
@@ -11209,17 +11073,6 @@
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
-      }
-    },
-    "css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
-      "dev": true,
-      "requires": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
       }
     },
     "css-tree": {
@@ -13395,13 +13248,6 @@
         "scheduler": "^0.22.0"
       }
     },
-    "react-is": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
-      "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==",
-      "dev": true,
-      "peer": true
-    },
     "react-query": {
       "version": "3.38.0",
       "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.38.0.tgz",
@@ -13829,12 +13675,6 @@
         "kind-of": "^6.0.2"
       }
     },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13985,24 +13825,6 @@
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
       "dev": true,
       "requires": {}
-    },
-    "styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
-      }
     },
     "stylis": {
       "version": "4.0.13",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "react-router-dom": "^6.3.0",
     "recoil": "^0.7.1",
     "style-loader": "^3.3.1",
-    "styled-components": "^5.3.5",
     "tailwindcss": "^3.0.24",
     "ts-loader": "^9.2.8",
     "typescript": "^4.6.3",

--- a/src/components/Navigation/NavBar.tsx
+++ b/src/components/Navigation/NavBar.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
+
 import HomeIcon from '@/assets/home.svg';
 import HamburgerIcon from '@/assets/hamburger.svg';
 import ChatIcon from '@/assets/chat.svg';

--- a/src/components/Typography/Title.tsx
+++ b/src/components/Typography/Title.tsx
@@ -1,5 +1,5 @@
 import React, { ReactChild } from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 
 const Title = ({ children }: { children: ReactChild }): JSX.Element => {
   return <StyledTitle>{children}</StyledTitle>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RecoilRoot } from 'recoil';
-import { ThemeProvider } from '@emotion/react';
+import { ThemeProvider, Global, css } from '@emotion/react';
 import baseTheme from './styles/baseTheme';
 import './styles/globals.css';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import GlobalStyles from './styles/globalStyles';
+
 import NavBar from '@/components/Navigation/NavBar';
 import Main from './pages/Main';
 import ChatRoom from './pages/ChatRoom';
@@ -17,8 +18,12 @@ function RootWithCallbackAfterRender() {
 
   return (
     <React.Fragment>
-      <GlobalStyles />
       <ThemeProvider theme={baseTheme}>
+        <Global
+          styles={css`
+            ${GlobalStyles}
+          `}
+        />
         <RecoilRoot>
           <BrowserRouter>
             <NavBar />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RecoilRoot } from 'recoil';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider } from '@emotion/react';
 import baseTheme from './styles/baseTheme';
 import './styles/globals.css';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -1,6 +1,4 @@
-import { createGlobalStyle } from 'styled-components';
-
-const GlobalStyles = createGlobalStyle`
+export const GlobalStyles = `
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
 
   * {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*", "custom.d.ts"],
+  "include": ["src/**/*", "custom.d.ts", "emotion.d.ts"],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "module": "commonjs",


### PR DESCRIPTION
### Related to Any Issues?
- styled-components 를 emotion 으로 대체
### What's Changed?
- emotion.d.ts 에 사용되는 모듈 타입 정의
- styled-components에서 사용되던 createGlobalStyles, ThemeProvider 등 대체
- styled-components 디펜던시 제거

### Any Screenshots?


