### PR TITLE
feature: 채팅방 프로필 이미지 컴포넌트 추가

### DIFF
--- a/public/assets/chatedge-right.svg
+++ b/public/assets/chatedge-right.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="11" viewBox="0 0 16 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M16 0H0.77193V10.5L16 0Z" fill="white"/>
+<path d="M16 0H0V10.5L16 0Z" fill="white"/>
 </svg>

--- a/src/components/ChatBubble/index.tsx
+++ b/src/components/ChatBubble/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, ReactNode } from 'react';
 import styled from '@emotion/styled';
 import ChatEdgeLeftSvg from '@/assets/chatedge-left.svg';
 import ChatEdgeRightSvg from '@/assets/chatedge-right.svg';
@@ -8,7 +8,7 @@ const ChatBubble = ({
   children,
   edgeLocation = ChatBubbleEdgeType.LEFT,
 }: {
-  children: string;
+  children: ReactNode;
   edgeLocation?: keyof typeof ChatBubbleEdgeType;
 }): JSX.Element => {
   return (
@@ -29,7 +29,6 @@ const ChatBubble = ({
 };
 
 const StyledChatBubble = styled.div`
-  box-sizing: border-box;
   display: inline-flex;
   position: relative;
   padding: 1.5rem;

--- a/src/components/ChatProfileImg/index.tsx
+++ b/src/components/ChatProfileImg/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+const ChatProfileImg = ({ alt, src }: { alt: string; src: string }): JSX.Element => {
+  return <StyledChatProfileImg src={src}></StyledChatProfileImg>;
+};
+
+const StyledChatProfileImg = styled.img`
+  width: 6rem;
+  height: 6rem;
+  border-radius: 100%;
+`;
+
+export default ChatProfileImg;

--- a/src/components/ChatRoomRow/index.tsx
+++ b/src/components/ChatRoomRow/index.tsx
@@ -1,0 +1,36 @@
+import React, { PropsWithChildren } from 'react';
+import styled from '@emotion/styled';
+import { ChatBubbleEdgeType } from '@/constants/components';
+import ChatProfileImg from '@/components/ChatProfileImg';
+import ChatBubble from '@/components/ChatBubble';
+
+interface ChatRoomRowProps {
+  imgAlt?: string;
+  imgSrc?: string;
+  isMyChat: boolean;
+}
+
+const ChatRoomRow = ({ children, imgAlt, imgSrc, isMyChat }: PropsWithChildren<ChatRoomRowProps>) => {
+  return (
+    <StyledChatRoomRow>
+      {isMyChat && <ChatBubble edgeLocation={ChatBubbleEdgeType.RIGHT}>{children}</ChatBubble>}
+      {!isMyChat && (
+        <>
+          <ChatProfileImg alt={imgAlt} src={imgSrc} />
+          <ChatBubble>{children}</ChatBubble>
+        </>
+      )}
+    </StyledChatRoomRow>
+  );
+};
+
+const StyledChatRoomRow = styled.div`
+  display: flex;
+  padding: ${({ theme }) => theme.gutter.size16};
+
+  > img {
+    margin-right: ${({ theme }) => theme.gutter.size8};
+  }
+`;
+
+export default ChatRoomRow;

--- a/src/pages/ChatRoom.tsx
+++ b/src/pages/ChatRoom.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import CommonTitle from '@/components/Typography/Title';
-import ChatBubble from '@/components/ChatBubble';
+import ChatRoomRow from '@/components/ChatRoomRow';
 import styled from '@emotion/styled';
-import { ChatBubbleEdgeType } from '@/constants/components';
 
 function ChatRoom() {
   return (
     <StyledChatRoom>
       <CommonTitle>채팅방 화면</CommonTitle>
-      <ChatRoomRow>
-        <ChatBubble>ㅇ아아아아아아아아아아</ChatBubble>
+      <ChatRoomRow imgSrc="https://cdn.pixabay.com/photo/2022/01/29/06/07/couple-6976409_1280.jpg" isMyChat={false}>
+        안녕하세요~~
       </ChatRoomRow>
-      <ChatRoomRow>
-        <ChatBubble edgeLocation={ChatBubbleEdgeType.RIGHT}>어쩌구저쩌구</ChatBubble>
+      <ChatRoomRow imgSrc="https://cdn.pixabay.com/photo/2022/01/29/06/07/couple-6976409_1280.jpg" isMyChat={true}>
+        아아앋가ㅓ다거
       </ChatRoomRow>
     </StyledChatRoom>
   );
@@ -21,10 +20,6 @@ function ChatRoom() {
 const StyledChatRoom = styled.div`
   background-color: ${({ theme }) => theme.color.primary};
   height: 100vh;
-`;
-
-const ChatRoomRow = styled.div`
-  display: block;
 `;
 
 export default ChatRoom;


### PR DESCRIPTION
### Related to Any Issues?
- 
### What's Changed?
- 채팅방 프로필 이미지 컴포넌트 추가
- ChatRoomRow를 컴포넌트로 분리 - 내가 쓴 채팅인지 다른이가 쓴 채팅인지에 따라 프로필이미지 컴포넌트 유무가 달라지는 컴포넌트

### Any Screenshots?
<img width="553" alt="Screen Shot 2022-05-10 at 9 34 53 PM" src="https://user-images.githubusercontent.com/46391618/167629411-db43ce89-dff5-4f36-a29b-01c9d2f9f15e.png">


