### PR TITLE
feature: 마이페이지 라우트 추가, Layout 컴포넌트 추가 

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,0 +1,18 @@
+import React, { PropsWithChildren } from 'react';
+import styled from '@emotion/styled';
+
+interface LayoutProps {
+  bgColor?: string;
+}
+
+function Layout({ children, bgColor }: PropsWithChildren<LayoutProps>) {
+  return <StyledLayout bgColor={bgColor}>{children}</StyledLayout>;
+}
+
+const StyledLayout = styled.div<{ bgColor: string }>`
+  height: calc(100vh - 6rem);
+  padding: 3.6rem 2rem;
+  background-color: ${({ bgColor, theme }) => (bgColor ? bgColor : theme.color.primary)};
+`;
+
+export default Layout;

--- a/src/components/Navigation/NavBar.tsx
+++ b/src/components/Navigation/NavBar.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 
 import HomeIcon from '@/assets/home.svg';
 import HamburgerIcon from '@/assets/hamburger.svg';
@@ -9,9 +10,15 @@ import MyPageIcon from '@/assets/mypage.svg';
 const NavBar = (): JSX.Element => {
   return (
     <StyledNavBar>
-      <HomeIcon />
-      <ChatIcon />
-      <MyPageIcon />
+      <Link to="/">
+        <HomeIcon />
+      </Link>
+      <Link to="/chatroom">
+        <ChatIcon />
+      </Link>
+      <Link to="/mypage">
+        <MyPageIcon />
+      </Link>
       <HamburgerIcon />
     </StyledNavBar>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import ChatRoom from './pages/ChatRoom';
 import ChatRoomDescription from './pages/ChatRoomDescription';
 import Main from './pages/Main';
 import SignIn from './pages/SignIn';
+import MyPage from './pages/MyPage';
 import baseTheme from './styles/baseTheme';
 import GlobalStyles from './styles/globalStyles';
 
@@ -32,6 +33,7 @@ function RootWithCallbackAfterRender() {
               <Route path="chatroom" element={<ChatRoom />} />
               <Route path="starting-chatroom" element={<ChatRoomDescription />} />
               <Route path="sign-in" element={<SignIn />} />
+              <Route path="mypage" element={<MyPage />} />
             </Routes>
           </BrowserRouter>
         </RecoilRoot>

--- a/src/pages/ChatRoom.tsx
+++ b/src/pages/ChatRoom.tsx
@@ -2,18 +2,21 @@ import React from 'react';
 import CommonTitle from '@/components/Typography/Title';
 import ChatRoomRow from '@/components/ChatRoomRow';
 import styled from '@emotion/styled';
+import Layout from '@/components/Layout';
 
 function ChatRoom() {
   return (
-    <StyledChatRoom>
-      <CommonTitle>채팅방 화면</CommonTitle>
-      <ChatRoomRow imgSrc="https://cdn.pixabay.com/photo/2022/01/29/06/07/couple-6976409_1280.jpg" isMyChat={false}>
-        안녕하세요~~
-      </ChatRoomRow>
-      <ChatRoomRow imgSrc="https://cdn.pixabay.com/photo/2022/01/29/06/07/couple-6976409_1280.jpg" isMyChat={true}>
-        아아앋가ㅓ다거
-      </ChatRoomRow>
-    </StyledChatRoom>
+    <Layout>
+      <StyledChatRoom>
+        <CommonTitle>채팅방 화면</CommonTitle>
+        <ChatRoomRow imgSrc="https://cdn.pixabay.com/photo/2022/01/29/06/07/couple-6976409_1280.jpg" isMyChat={false}>
+          안녕하세요~~
+        </ChatRoomRow>
+        <ChatRoomRow imgSrc="https://cdn.pixabay.com/photo/2022/01/29/06/07/couple-6976409_1280.jpg" isMyChat={true}>
+          아아앋가ㅓ다거
+        </ChatRoomRow>
+      </StyledChatRoom>
+    </Layout>
   );
 }
 

--- a/src/pages/ChatRoomDescription.tsx
+++ b/src/pages/ChatRoomDescription.tsx
@@ -5,6 +5,7 @@ import StartingChatInput from '@/components/StartingChatInput';
 import useModal from '@/hooks/useModal';
 import { ChangeEvent, useState } from 'react';
 import { useRecoilValue } from 'recoil';
+import Layout from '@/components/Layout';
 
 const categories = [
   '커피챗',
@@ -44,7 +45,7 @@ const ChatRoomDescription = () => {
   };
 
   return (
-    <>
+    <Layout>
       <StartingChatInput
         id="category"
         value={inputs.category}
@@ -68,7 +69,7 @@ const ChatRoomDescription = () => {
           </SelectableModal>
         </ModalPortal>
       )}
-    </>
+    </Layout>
   );
 };
 

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CommonTitle from '@/components/Typography/Title';
+import Layout from '@/components/Layout';
+
+function MyPage() {
+  return (
+    <Layout>
+      <CommonTitle>마이페이지</CommonTitle>
+    </Layout>
+  );
+}
+
+export default MyPage;

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,7 +1,13 @@
+import Layout from '@/components/Layout';
+
 const isName = /^[가-힣]{2,30}$/;
 
 const SignIn = () => {
-  return <></>;
+  return (
+    <Layout>
+      <></>
+    </Layout>
+  );
 };
 
 export default SignIn;


### PR DESCRIPTION
### Related to Any Issues?
- 
### What's Changed?
- 네비게이션바에 라우트 연결
- 마이페이지 라우트 추가
- Layout 컴포넌트 추가 (기본적으로 primary background 사용, props로 다른 컬러 적용 가능)

### Any Screenshots?
<img width="852" alt="Screen Shot 2022-05-14 at 3 27 15 PM" src="https://user-images.githubusercontent.com/46391618/168413925-f2621337-0a89-453d-8f8b-d328fc0d06b4.png">
<img width="787" alt="Screen Shot 2022-05-14 at 3 27 12 PM" src="https://user-images.githubusercontent.com/46391618/168413926-891d54af-3b7c-42bb-b427-b78cf52c5df6.png">

